### PR TITLE
Improved JS Code to ignore unrelated images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,31 @@
 
 4.  Paste below code and press Enter:
 
-        let jspdf = document.createElement( "script" );
-        jspdf.onload = function () {
-        let pdf = new jsPDF();
-        let elements = document.getElementsByTagName( "img" );
-        for ( let i in elements) {
+```
+let jspdf = document.createElement("script");
+jspdf.onload = function() {
+    let pdf = new jsPDF();
+    let elements = document.querySelectorAll('img[src^="blob:"][alt^="Page "]');
+    for (let i in elements) {
         let img = elements[i];
         if (!/^blob:/.test(img.src)) {
-        continue ;
+            continue;
         }
-        let canvasElement = document.createElement( 'canvas' );
-        let con = canvasElement.getContext( "2d" );
+        let canvasElement = document.createElement('canvas');
+        let con = canvasElement.getContext("2d");
         canvasElement.width = img.width;
         canvasElement.height = img.height;
-        con.drawImage(img, 0, 0,img.width, img.height);
-        let imgData = canvasElement.toDataURL( "image/jpeg" , 1.0);
-        pdf.addImage(imgData, 'JPEG' , 0, 0);
+        con.drawImage(img, 0, 0, img.width, img.height);
+        let imgData = canvasElement.toDataURL("image/jpeg", 1.0);
+        pdf.addImage(imgData, 'JPEG', 0, 0);
         pdf.addPage();
-        }
-        pdf.save( "download.pdf" );
-        };
-        jspdf.src = 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/1.3.2/jspdf.min.js' ;
-        document.body.appendChild(jspdf);
+    }
+    var pageCount = pdf.internal.getNumberOfPages();
+    pdf.deletePage(pageCount)
+    pdf.save("download.pdf");
+};
+jspdf.src = 'https://cdnjs.cloudflare.com/ajax/libs/jspdf/1.3.2/jspdf.min.js';
+document.body.appendChild(jspdf);
+```
 
 5. Now, the pdf file start to download. This might take a few minutes depending on the file size.


### PR DESCRIPTION
The existing code may include irrelevant images to the pdf. After checking the HTML, I found all relevant images have a "alt" tag with "page" in the keyword.

Lastly, the updated code will also remove the last empty page in the pdf.